### PR TITLE
incluindo campo para "endereço do local do estágio" e removendo campos do pdf de parecer

### DIFF
--- a/app/Http/Requests/EstagioRequest.php
+++ b/app/Http/Requests/EstagioRequest.php
@@ -61,6 +61,7 @@ class EstagioRequest extends FormRequest
             'cargo_do_supervisor_estagio' => 'required|max:255',
             'telefone_do_supervisor_estagio' => 'required|max:255',
             'email_do_supervisor_estagio' => 'required|email|max:255',
+            'endereco_local_estagio' => 'required|max:255',
 
             //
             'horariocompativel' => 'nullable',

--- a/app/Models/Estagio.php
+++ b/app/Models/Estagio.php
@@ -106,7 +106,7 @@ class Estagio extends Model implements Auditable
         $areas_fixas =  [
             'Ensino/Educação',
             'Editoração',
-            'Tradução/ Interpretação',
+            'Tradução, interpretação, legendagem',
             'Revisão, correção e/ou produção de textos',
             'Tecnologia -  Internet, mídias e ambientes digitais',
             'Administração (serviços gerais, secretariado, recepção, etc)',

--- a/app/Utils/Mapeamento.php
+++ b/app/Utils/Mapeamento.php
@@ -65,6 +65,7 @@ class Mapeamento
             'nome_do_representante_opcional' => 'Nome do representante da empresa',
             'cargo_do_representante_opcional' => 'Cargo do representante da empresa',
             'email_do_representante_opcional' => 'E-mail do representante da empresa',
+            'endereco_local_estagio' => 'Endereço do local do estágio',
             'id' => 'ID',
         ];
 

--- a/database/migrations/2025_06_11_171049_add_endereco_local_estagio_to_estagios_table.php
+++ b/database/migrations/2025_06_11_171049_add_endereco_local_estagio_to_estagios_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('estagios', function (Blueprint $table) {
+            $table->string('endereco_local_estagio')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('estagios', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/settings/defaults/parecer.txt
+++ b/database/settings/defaults/parecer.txt
@@ -12,6 +12,7 @@
     Curso: <b>{{ $estagio->curso }}</b>, período <b>{{ $estagio->periodo }}</b><br><br>
     Empresa: <b>{{ $estagio->empresa->nome }}</b><br><br>
     Área de atuação da Empresa: <b>S{{ $estagio->empresa->area_de_atuacao }}</b><br><br>
+    Endereço do local do estágio: <b>{{$estagio->endereco_local_estagio}}</b><br><br>
     Período do Estágio<br>
     Início: <b>{{$estagio->data_inicial}}</b><br>
     Término: <b>{{$estagio->data_final}}</b>
@@ -21,10 +22,6 @@
 <p>As Atividades propostas no plano de estágio são pertinentes ao curso de origem do aluno?: <b>{{ $estagio->atividadespertinentes }}</b></p>
 
 <p>Justifique: <b>{{ $estagio->atividadesjustificativa }}</b></p>
-
-<p>Avalie o desempenho acadêmico do aluno: <b>{{ $estagio->desempenhoacademico }}</b></p>
-
-<p>Média ponderada com reprovação: <b>{{ $estagio->media_ponderada }}</b></p>
 
 <p>O horário do estágio é compatível com os horários disponíveis na grade horária do aluno?: <b>{{ $estagio->horariocompativel }}</b></p>
 

--- a/resources/views/estagios/form.blade.php
+++ b/resources/views/estagios/form.blade.php
@@ -188,6 +188,14 @@ aditivo por até 12 meses.
                     <input type="text" maxlength="11" class="form-control" id="telefone-com-ddd" name="telefone_de_contato" value="{{old('telefone_de_contato',$estagio->telefone_de_contato)}}">
                 </div></div>
             </div>
+            <div class="row">
+                <div class="col-sm form-group">
+                    <div class="form-group">
+                        <label for="endereco_estagio" class="required">Endereço do local do estágio</label>
+                        <input type="text" class="form-control" name="endereco_local_estagio" value="{{ old('endereco_local_estagio',$estagio->endereco_local_estagio) }}">
+                    </div>
+                </div>
+            </div>
         <div class="row">
             <div class="col-sm form-group">
                 <div class="form-group">


### PR DESCRIPTION
## A pedido de uma professora numa reunião da CG, os seguintes itens foram alterados:
 - A empresa precisa especificar o endereço que ocorrerá o estágio, pois, no caso de uma empresa possuir vários endereços, ela deverá especificar em qual será realizado o estágio;
 - os campos que indicam a avaliação do desempenho do aluno feita pelo docente e a média ponderada do aluno foram removidas do PDF do parecer de mérito.